### PR TITLE
feat(intake): test form submission without PDF (mocked via Google Apps Script)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,26 @@
+// vite.config.ts
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+// ✅ Pega aquí el path EXACTO de tu deployment de GAS (lo que va entre /macros y /exec)
+const GAS_EXEC_PATH =
+  '/macros/s/AKfycbzFCskYeqfgB12j62DOAX3E6ppIJKCwyzvsifAkgbEm9Kei__n8djxspvoNvNrRu0cSuw/exec'
 
-// https://vite.dev/config/
+// Si prefieres, puedes tomarlo de una env: const GAS_EXEC_PATH = process.env.VITE_GAS_EXEC_PATH!
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      // cualquier request a /gas en dev se reenviará a script.google.com + GAS_EXEC_PATH
+      '/gas': {
+        target: 'https://script.google.com',
+        changeOrigin: true,
+        secure: true,
+        // /gas -> /macros/s/<ID>/exec
+        rewrite: (path) => path.replace(/^\/gas/, GAS_EXEC_PATH),
+      },
+    },
+  },
 })


### PR DESCRIPTION
### Overview
This PR introduces a safe testing setup to validate the intake form flow end-to-end without the real backend.

### What’s included
- Created a temporary branch `feat/test-form-without-pdf` to test the form submission against a **mock backend**.
- Connected the frontend to a **Google Apps Script Web App** that writes to a test Google Sheet.
- The script exposes two endpoints:
  - `doGet` → health check
  - `doPost` → receives form data and appends a new row
- The Web App is deployed publicly (“Anyone” access) to avoid CORS/auth issues.
- Updated the frontend submission logic to use `URLSearchParams` instead of `FormData`.
- Temporarily disabled the PDF requirement to isolate form field handling.
- Validated success and error banner rendering.

### Next Steps
- With Kevin’s new OAuth client and service account credentials, we’ll move forward with **realistic end-to-end testing** using the new sandbox backend.
- The next branch (`feat/sandbox-e2e-intake`) will reconnect the form to the backend `/intake` endpoint, re-enable PDF upload, and test the full Drive → Sheet integration.

### Notes
- No secrets or private keys are included.
- `.env` remains excluded from version control.